### PR TITLE
Replace legacy `action:` from tasks

### DIFF
--- a/cluster/roles/apache2/tasks/main.yml
+++ b/cluster/roles/apache2/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Apache2 On Debian 8 and down
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - apache2-mpm-event
   - php5-gd
@@ -11,7 +13,9 @@
   when: ansible_distribution == "Debian" and ansible_distribution_major_version|int < 9
 
 - name: Install Apache2 On Debian 9 and up
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - apache2
   - php7.0-gd

--- a/cluster/roles/common/tasks/main.yml
+++ b/cluster/roles/common/tasks/main.yml
@@ -3,7 +3,9 @@
    apt: upgrade=dist update_cache=yes
 
  - name: Install common packages
-   action: apt pkg={{ item }} state=present
+   apt:
+     pkg: "{{ item }}"
+     state: present
    with_items:
    - jnettop
    - curl

--- a/cluster/roles/filestorage/tasks/main.yml
+++ b/cluster/roles/filestorage/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install NFS client
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - nfs-common
   - nfs4-acl-tools

--- a/cluster/roles/mariadb/tasks/main.yml
+++ b/cluster/roles/mariadb/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: MariaDB prereqs
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - python-mysqldb
 

--- a/cluster/roles/wordpress/tasks/main.yml
+++ b/cluster/roles/wordpress/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Prereq
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - python-mysqldb
   - sudo

--- a/single/roles/apache2/tasks/main.yml
+++ b/single/roles/apache2/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Apache2 On Debian 8 and down
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - apache2-mpm-event
   - php5-gd
@@ -11,7 +13,9 @@
   when: ansible_distribution == "Debian" and ansible_distribution_major_version|int < 9
 
 - name: Install Apache2 On Debian 9 and up
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - apache2
   - php7.0-gd

--- a/single/roles/common/tasks/main.yml
+++ b/single/roles/common/tasks/main.yml
@@ -3,7 +3,9 @@
    apt: upgrade=dist update_cache=yes
 
  - name: Install common packages
-   action: apt pkg={{ item }} state=present
+   apt:
+     pkg: "{{ item }}"
+     state: present
    with_items:
    - jnettop
    - curl

--- a/single/roles/mariadb/tasks/main.yml
+++ b/single/roles/mariadb/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: MariaDB prereqs
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - python-mysqldb
 

--- a/single/roles/wordpress/tasks/main.yml
+++ b/single/roles/wordpress/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: Install Prereq
-  action: apt pkg={{ item }} state=present
+  apt:
+    pkg: "{{ item }}"
+    state: present
   with_items:
   - python-mysqldb
   - sudo


### PR DESCRIPTION
Use the apt module instead of `action: apt`.